### PR TITLE
Fix UWP Avatar transition

### DIFF
--- a/src/Miunie.WindowsApp/ViewModels/StatusPageViewModel.cs
+++ b/src/Miunie.WindowsApp/ViewModels/StatusPageViewModel.cs
@@ -36,6 +36,7 @@ namespace Miunie.WindowsApp.ViewModels
             }
         }
 
+        public Action AvatarChanged;
 
         public Visibility ActionButtonIsVisible => _miunie.MiunieDiscord.ConnectionState != ConnectionState.CONNECTING 
             ? Visibility.Visible 
@@ -57,6 +58,8 @@ namespace Miunie.WindowsApp.ViewModels
             miunie.MiunieDiscord.ConnectionChanged += MiunieOnConnectionStateChanged;
             ConnectionStatus = "Not connected";
         }
+
+        public bool IsConnecting { get => _miunie.MiunieDiscord.ConnectionState == ConnectionState.CONNECTING; }
 
         public async void ToggleBotStart()
         {
@@ -89,6 +92,7 @@ namespace Miunie.WindowsApp.ViewModels
                     RaisePropertyChanged(nameof(ActionButtonIsVisible));
                     RaisePropertyChanged(nameof(ProgressBarIsVisible));
                     RaisePropertyChanged(nameof(BotAvatar));
+                    AvatarChanged?.Invoke();
                 });
         }
     }

--- a/src/Miunie.WindowsApp/Views/StatusPage.xaml
+++ b/src/Miunie.WindowsApp/Views/StatusPage.xaml
@@ -19,7 +19,7 @@
 
                 <Ellipse Fill="{ThemeResource SystemAccentColor}" 
                          Width="174" Height="172" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                
+
                 <Ellipse Width="175" Height="175" x:Name="BotAvatarBrush">
                     <Ellipse.Fill>
                         <ImageBrush ImageSource="{Binding BotAvatar}" />

--- a/src/Miunie.WindowsApp/Views/StatusPage.xaml
+++ b/src/Miunie.WindowsApp/Views/StatusPage.xaml
@@ -17,15 +17,47 @@
                   Height="175"
                   x:Name="MiunieAvatar">
 
-                <Ellipse Fill="{ThemeResource SystemControlBackgroundAccentBrush}" 
-                         Width="175" Height="175"/>
-
-                <Ellipse Width="175" Height="175" >
+                <Ellipse Fill="{ThemeResource SystemAccentColor}" 
+                         Width="174" Height="172" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                
+                <Ellipse Width="175" Height="175" x:Name="BotAvatarBrush">
                     <Ellipse.Fill>
                         <ImageBrush ImageSource="{Binding BotAvatar}" />
                     </Ellipse.Fill>
                 </Ellipse>
 
+                <Grid x:Name="AvatarLoadingFacade" Opacity="0">
+                    <Ellipse Fill="{ThemeResource SystemControlBaseHighAcrylicElementMediumBrush}" 
+                             Width="175" Height="175"/>
+
+                    <ProgressRing IsActive="True" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" Width="40" Height="40" />
+                </Grid>
+
+                <Grid.Resources>
+                    <Storyboard x:Name="FadeOutAvatarStoryboard">
+                        <DoubleAnimation Storyboard.TargetName="AvatarLoadingFacade"
+                                         Storyboard.TargetProperty="Opacity"
+                                         To="1"
+                                         Duration="0:0:0.2"/>
+                        <DoubleAnimation Storyboard.TargetName="BotAvatarBrush"
+                                         Storyboard.TargetProperty="Opacity"
+                                         BeginTime="0:0:0.2"
+                                         To="0"
+                                         Duration="0:0:0.2"/>
+                    </Storyboard>
+                    <Storyboard x:Name="FadeInAvatarStoryboard">
+                        <DoubleAnimation Storyboard.TargetName="BotAvatarBrush"
+                                         Storyboard.TargetProperty="Opacity"
+                                         To="1"
+                                         BeginTime="0:0:0.5"
+                                         Duration="0:0:0.5"/>
+                        <DoubleAnimation Storyboard.TargetName="AvatarLoadingFacade"
+                                         Storyboard.TargetProperty="Opacity"
+                                         BeginTime="0:0:1.0"
+                                         To="0"
+                                         Duration="0:0:0.2"/>
+                    </Storyboard>
+                </Grid.Resources>
             </Grid>
 
 
@@ -45,8 +77,6 @@
                         Style="{ThemeResource ButtonRevealStyle}" 
                         Click="ActionBtn_OnClick"/>
             </Grid>
-
-
 
         </StackPanel>
         <TextBlock HorizontalAlignment="Center"

--- a/src/Miunie.WindowsApp/Views/StatusPage.xaml.cs
+++ b/src/Miunie.WindowsApp/Views/StatusPage.xaml.cs
@@ -27,6 +27,19 @@ namespace Miunie.WindowsApp.Views
             this.InitializeComponent();
             _vm = DataContext as StatusPageViewModel;
             NavigationCacheMode = NavigationCacheMode.Enabled;
+            _vm.AvatarChanged = OnAvatarChanged;
+        }
+
+        private void OnAvatarChanged()
+        {
+            FadeOutAvatarStoryboard.Begin();
+
+            if (_vm.IsConnecting) return;
+
+            FadeOutAvatarStoryboard.Completed += (object sbs, object sbe) =>
+            {
+                FadeInAvatarStoryboard.Begin();
+            };
         }
 
         private void ActionBtn_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Related Issue

This is a fix for the UWP UI issue. You used to be able to see the Windows accent color flash for a second before your new avatar loads. Now there is an animated loading transition that makes it more seamless.

Fixes #132 

## Changes
Implement a pretty hacky system for notifying the view that the Avatar property changed.

## Expected Feedback
A general sanity check would be appreciated. ❤️
If you have a Windows 10 machine and would test it yourself, that would be even more awesome! 🎉 🍾 

