### PR TITLE
Fix Console GUI Freezing

### DIFF
--- a/src/Miunie.ConsoleApp/Program.cs
+++ b/src/Miunie.ConsoleApp/Program.cs
@@ -22,7 +22,7 @@ namespace Miunie.ConsoleApp
             _configManager = InversionOfControl.Provider.GetRequiredService<ConfigManager>();
             _editor = InversionOfControl.Provider.GetRequiredService<ConfigurationFileEditor>();
             _miunie.MiunieDiscord.ConnectionChanged += MiunieOnConnectionStateChanged;
-            await HandleInput();
+            HandleInput();
         }
 
         private static async Task RunHeadless(string[] args)
@@ -46,7 +46,7 @@ namespace Miunie.ConsoleApp
             DrawMiunieState();
         }
 
-        private static async Task HandleInput()
+        private static void HandleInput()
         {
             while (true)
             {

--- a/src/Miunie.ConsoleApp/Program.cs
+++ b/src/Miunie.ConsoleApp/Program.cs
@@ -86,11 +86,12 @@ namespace Miunie.ConsoleApp
                         if (_miunie.MiunieDiscord.ConnectionState == ConnectionState.CONNECTED)
                         {
                             _miunie.Stop();
+                            AnyKeyToContinue();
                         }
                         else if(_miunie.MiunieDiscord.ConnectionState == ConnectionState.DISCONNECTED)
                         {
                             _miunie.BotConfiguration.DiscordToken = _configManager.GetValueFor("DiscordToken");
-                            await _miunie.StartAsync();
+                            _ = _miunie.StartAsync();
                             AnyKeyToContinue();
                         }
                         break;


### PR DESCRIPTION
## Related Issue

Fixes #193 

## Changes
Instead of awaiting the `StartAsync` method (which contains a Task.Delay of -1), we just discard the Task after invoking it.

This seems to fix the issue. It's interesting, however, because UWP does the same thing and doesn't get blocked. It is possible that UWP has some sort of mechanism to separate that into a different thread.

_I also added a `AnyKeyToContinue` call after stopping the bot, because the UI got all weird without it._

## Expected Feedback
Any idea why UWP would work? See something wrong with this fix?
Any suggestions appreciated. 😊 
And of course... 🧠 a sanity check.

