### PR TITLE
Fix Connection State Updating

### DIFF
--- a/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -54,10 +54,10 @@ namespace Miunie.Avalonia.ViewModels
 
         private void ConectionStateChanged(object sender, EventArgs e)
         {
-            _connectionStatusText = _miunie.MiunieDiscord.ConnectionState switch
+            ConnectionStatusText = _miunie.MiunieDiscord.ConnectionState switch
             {
-                ConnectionState.CONNECTED => "Connecting",
-                ConnectionState.CONNECTING => "Connected",
+                ConnectionState.CONNECTING => "Connecting",
+                ConnectionState.CONNECTED => "Connected",
                 ConnectionState.DISCONNECTED => "Disconnected",
                 _ => "Unknown State"
             };


### PR DESCRIPTION
## Related Issue

Fixes #233 

## Changes

The switch in `MainWIndowViewModel.cs` was updating the private field instead of the Property that the `TextBlock` is bound to.

Now the Property is updated instead of the private field.

## Expected Feedback

Test the Avalonia UI on a Windows machine.
