### PR TITLE
Add Avalonia avatar switch

### DIFF
--- a/src/Miunie.Avalonia/InversionOfControl.cs
+++ b/src/Miunie.Avalonia/InversionOfControl.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Miunie.Avalonia.Utilities;
 using Miunie.Core.Infrastructure;
 using Miunie.Core.Logging;
 using Miunie.InversionOfControl;
 using Miunie.Logger;
 using Miunie.SystemInfrastructure;
+using System.Net.Http;
 
 namespace Miunie.Avalonia
 {
@@ -31,6 +33,8 @@ namespace Miunie.Avalonia
                 .AddSingleton<ILogWriter>(s => s.GetRequiredService<ConsoleLogger>())
                 .AddTransient<IDateTime, SystemDateTime>()
                 .AddSingleton<IFileSystem, SystemFileSystem>()
+                .AddSingleton<HttpClient>()
+                .AddSingleton<UrlImageConverter>()
                 .AddMiunieTypes()
                 .BuildServiceProvider();
     }

--- a/src/Miunie.Avalonia/Miunie.Avalonia.csproj
+++ b/src/Miunie.Avalonia/Miunie.Avalonia.csproj
@@ -29,5 +29,8 @@
     <None Update="Assets\avalonia-icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\miunie-icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Miunie.Avalonia/Utilities/UrlImageConverter.cs
+++ b/src/Miunie.Avalonia/Utilities/UrlImageConverter.cs
@@ -1,0 +1,29 @@
+﻿using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Miunie.Avalonia.Utilities
+{
+    public class UrlImageConverter
+    {
+        private readonly HttpClient _httpClient;
+
+        public UrlImageConverter(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<Bitmap> UrlToBitmapAsync(string url)
+        {
+            Bitmap bitmap;
+            var byteArray = await _httpClient.GetByteArrayAsync(url);
+            using (var ms = new MemoryStream(byteArray))
+            {
+                bitmap = new Bitmap(ms);
+            }
+            return bitmap;
+        }
+    }
+}

--- a/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -24,7 +24,7 @@ namespace Miunie.Avalonia.ViewModels
         {
             _miunie = ActivatorUtilities.CreateInstance<MiunieBot>(InversionOfControl.Provider);
             _urlImageConverter = InversionOfControl.Provider.GetRequiredService<UrlImageConverter>();
-            _miunieBitmap = new Bitmap(@".\Assets\miunie-icon.png");
+            _miunieBitmap = new Bitmap("Assets/miunie-icon.png");
             _botAvatarImage = _miunieBitmap;
             _miunie.MiunieDiscord.ConnectionChanged += ConectionStateChanged;
         }

--- a/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/Miunie.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -1,22 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Miunie.Avalonia.Utilities;
 using Miunie.Core;
 using Miunie.Core.Entities;
 using Miunie.Core.Logging;
 using ReactiveUI;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
 
 namespace Miunie.Avalonia.ViewModels
 {
     public class MainWindowViewModel : ViewModelBase
     {
         private readonly MiunieBot _miunie;
+        private readonly UrlImageConverter _urlImageConverter;
+        private readonly Bitmap _miunieBitmap;
 
         public MainWindowViewModel()
         {
             _miunie = ActivatorUtilities.CreateInstance<MiunieBot>(InversionOfControl.Provider);
+            _urlImageConverter = InversionOfControl.Provider.GetRequiredService<UrlImageConverter>();
+            _miunieBitmap = new Bitmap(@".\Assets\miunie-icon.png");
+            _botAvatarImage = _miunieBitmap;
             _miunie.MiunieDiscord.ConnectionChanged += ConectionStateChanged;
         }
 
@@ -26,6 +35,14 @@ namespace Miunie.Avalonia.ViewModels
         { 
             get { return _connectionStatusText; }
             set { this.RaiseAndSetIfChanged(ref _connectionStatusText, value); }
+        }
+
+        private Bitmap _botAvatarImage;
+
+        public Bitmap BotAvatarImage
+        {
+            get { return _botAvatarImage; }
+            set { this.RaiseAndSetIfChanged(ref _botAvatarImage, value); }
         }
 
         private string _discordToken = "";
@@ -55,12 +72,29 @@ namespace Miunie.Avalonia.ViewModels
 
         private void ConectionStateChanged(object sender, EventArgs e)
         {
+            UpdateConectionStateText();
+            UpdateBotAvatar();
+        }
+
+        private void UpdateConectionStateText()
+        {
             ConnectionStatusText = _miunie.MiunieDiscord.ConnectionState switch
             {
                 ConnectionState.CONNECTING => "Connecting",
                 ConnectionState.CONNECTED => "Connected",
                 ConnectionState.DISCONNECTED => "Disconnected",
                 _ => "Unknown State"
+            };
+        }
+
+        private async void UpdateBotAvatar()
+        {
+            BotAvatarImage = _miunie.MiunieDiscord.ConnectionState switch
+            {
+                ConnectionState.CONNECTED => await _urlImageConverter.UrlToBitmapAsync(_miunie.MiunieDiscord.GetBotAvatarUrl()),
+                ConnectionState.CONNECTING => _miunieBitmap,
+                ConnectionState.DISCONNECTED => _miunieBitmap,
+                _ => _miunieBitmap
             };
         }
     }

--- a/src/Miunie.Avalonia/Views/MainWindow.xaml
+++ b/src/Miunie.Avalonia/Views/MainWindow.xaml
@@ -14,6 +14,7 @@
 
     <StackPanel>
         <TextBox PasswordChar="*" Watermark="Enter Token..." Text="{Binding DiscordToken, Mode=TwoWay}" />
+        <Image Source="{Binding BotAvatarImage}" HorizontalAlignment="Center" VerticalAlignment="Top" Width="63" Height="63"></Image>
         <TextBlock Text="{Binding ConnectionStatusText, Mode=OneWay}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Button Width="160" Command="{Binding StartButton_ClickCommand}">Start</Button>
         <Button Width="160" Command="{Binding StopButton_ClickCommand}">Stop</Button>


### PR DESCRIPTION
## Related Issue


Fixes #245 

## Changes
When miunie ConnectionState changes, the avalonia bot avatar image changes to the avatar of the currently logged in bot

## Expected Feedback
Insure it works on GNU/Linux
