### PR TITLE
UWP - Fix error when sending messages to readonly channels

### DIFF
--- a/src/Miunie.Core/Entities/Views/TextChannelView.cs
+++ b/src/Miunie.Core/Entities/Views/TextChannelView.cs
@@ -24,5 +24,7 @@ namespace Miunie.Core.Entities.Views
         public string Name { get; set; }
 
         public IEnumerable<MessageView> Messages { get; set; }
+
+        public bool CanSendMessages { get; set; }
     }
 }

--- a/src/Miunie.Discord/Impersonation.cs
+++ b/src/Miunie.Discord/Impersonation.cs
@@ -111,8 +111,12 @@ namespace Miunie.Discord
             {
                 Id = channel.Id,
                 Name = $"# {channel.Name}",
-                Messages = new MessageView[0]
+                Messages = new MessageView[0],
+                CanSendMessages = CanSendMessagesTo(channel)
             };
+
+        private bool CanSendMessagesTo(SocketTextChannel channel)
+            => channel.GetUser(_discord.Client.CurrentUser.Id)?.GetPermissions(channel).SendMessages ?? false;
 
         private bool IsViewableTextChannel(SocketGuildChannel c)
         {

--- a/src/Miunie.WindowsApp/ViewModels/ImpersonationChatPageViewModel.cs
+++ b/src/Miunie.WindowsApp/ViewModels/ImpersonationChatPageViewModel.cs
@@ -27,6 +27,7 @@ namespace Miunie.WindowsApp.ViewModels
                 _selectedChannel = value;
                 RaisePropertyChanged(nameof(SelectedChannel));
                 RaisePropertyChanged(nameof(IsMessageTextboxEnabled));
+                RaisePropertyChanged(nameof(SendMessageInputPlaceholder));
                 LoadMessagesAsync();
             }
         }
@@ -67,7 +68,9 @@ namespace Miunie.WindowsApp.ViewModels
             }
         }
 
-        public bool IsMessageTextboxEnabled => _selectedChannel != null;
+        public bool IsMessageTextboxEnabled => _selectedChannel?.CanSendMessages ?? false;
+
+        public string SendMessageInputPlaceholder => _selectedChannel?.CanSendMessages ?? true ? "Type your message here." : "This channel is read only.";
 
         public ICommand SendMessageCommand => new RelayCommand<string>(SendMessageAsMiunieAsync, CanSendMessage);
 

--- a/src/Miunie.WindowsApp/Views/ImpersonationChatPage.xaml
+++ b/src/Miunie.WindowsApp/Views/ImpersonationChatPage.xaml
@@ -73,7 +73,7 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <TextBox Grid.Row="1" x:Name="MessageTextBox" IsEnabled="{Binding IsMessageTextboxEnabled}" Text="{Binding MessageText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" u:EnterKeyHelpers.EnterKeyCommand="{Binding SendMessageCommand}" PlaceholderText="Type your message here." HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="0,5,0,10" />
+            <TextBox Grid.Row="1" x:Name="MessageTextBox" IsEnabled="{Binding IsMessageTextboxEnabled}" Text="{Binding MessageText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" u:EnterKeyHelpers.EnterKeyCommand="{Binding SendMessageCommand}" PlaceholderText="{Binding SendMessageInputPlaceholder}" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="0,5,0,10" />
             <Button Grid.Row="1" Grid.Column="1" Command="{Binding SendMessageCommand}" CommandParameter="{Binding ElementName=MessageTextBox, Path=Text, RelativeSource={RelativeSource Mode=TemplatedParent}}" FontFamily="Segoe MDL2 Assets" Content="&#xE725;" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="5,5,5,10"/>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Related Issue

Fixes #262 

## Changes

Added a `CanSendMessages` property to the channel's View model.
If messages cannot be sent, change placeholder for input box and disable it.

## Expected Feedback
A general sanity check would be appreciated.
But mostly try to run it on your Windows 10 machine.
